### PR TITLE
fix(worker): wire getChildrenValues callback in job processor

### DIFF
--- a/test/flow-advanced.test.ts
+++ b/test/flow-advanced.test.ts
@@ -115,57 +115,6 @@ describe('Advanced Flow - Embedded', () => {
     queue.close();
   }, 15000);
 
-  test('parent-child: job.getChildrenValues() works inside worker handler', async () => {
-    const flow = new FlowProducer({ embedded: true });
-    const queue = new Queue('flow-job-children', { embedded: true });
-    queue.obliterate();
-
-    let jobChildrenValues: Record<string, unknown> = {};
-    let resolve: () => void;
-    const done = new Promise<void>((r) => (resolve = r));
-
-    const worker = new Worker(
-      'flow-job-children',
-      async (job) => {
-        const data = job.data as { role: string; value?: number };
-
-        if (data.role === 'child') {
-          await Bun.sleep(50);
-          return { childResult: (data.value ?? 0) * 10 };
-        }
-
-        if (data.role === 'parent') {
-          jobChildrenValues = await job.getChildrenValues();
-          resolve!();
-          return { summary: 'done' };
-        }
-
-        return {};
-      },
-      { embedded: true, concurrency: 5 }
-    );
-
-    await flow.add({
-      name: 'parent',
-      queueName: 'flow-job-children',
-      data: { role: 'parent' },
-      children: [
-        { name: 'child-a', queueName: 'flow-job-children', data: { role: 'child', value: 3 } },
-        { name: 'child-b', queueName: 'flow-job-children', data: { role: 'child', value: 7 } },
-      ],
-    });
-
-    await done;
-    await Bun.sleep(200);
-
-    const values = Object.values(jobChildrenValues).map((v: any) => v.childResult).sort();
-    expect(values).toEqual([30, 70]);
-
-    await worker.close();
-    flow.close();
-    queue.close();
-  }, 15000);
-
   test('fan-out/fan-in: parallel tasks converge to final step', async () => {
     const flow = new FlowProducer({ embedded: true });
     const queue = new Queue('flow-fanout', { embedded: true });

--- a/test/flow-children.test.ts
+++ b/test/flow-children.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Flow Children Tests (Embedded Mode)
+ *
+ * Tests for job.getChildrenValues() inside worker handlers.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { Queue, Worker, FlowProducer, shutdownManager } from '../src/client';
+
+describe('Flow Children - Embedded', () => {
+  afterEach(() => {
+    shutdownManager();
+  });
+
+  test('job.getChildrenValues() returns child results inside worker handler', async () => {
+    const flow = new FlowProducer({ embedded: true });
+    const queue = new Queue('flow-job-children', { embedded: true });
+    queue.obliterate();
+
+    let jobChildrenValues: Record<string, unknown> = {};
+    let resolve: () => void;
+    const done = new Promise<void>((r) => (resolve = r));
+
+    const worker = new Worker(
+      'flow-job-children',
+      async (job) => {
+        const data = job.data as { role: string; value?: number };
+
+        if (data.role === 'child') {
+          await Bun.sleep(50);
+          return { childResult: (data.value ?? 0) * 10 };
+        }
+
+        if (data.role === 'parent') {
+          jobChildrenValues = await job.getChildrenValues();
+          resolve!();
+          return { summary: 'done' };
+        }
+
+        return {};
+      },
+      { embedded: true, concurrency: 5 }
+    );
+
+    await flow.add({
+      name: 'parent',
+      queueName: 'flow-job-children',
+      data: { role: 'parent' },
+      children: [
+        { name: 'child-a', queueName: 'flow-job-children', data: { role: 'child', value: 3 } },
+        { name: 'child-b', queueName: 'flow-job-children', data: { role: 'child', value: 7 } },
+      ],
+    });
+
+    await done;
+    await Bun.sleep(200);
+
+    const values = Object.values(jobChildrenValues)
+      .map((v) => (v as { childResult: number }).childResult)
+      .sort((a, b) => a - b);
+    expect(values).toEqual([30, 70]);
+
+    await worker.close();
+    flow.close();
+    queue.close();
+  }, 15000);
+});


### PR DESCRIPTION
## Summary

- `job.getChildrenValues()` inside a Worker handler always returns `{}` because the processor never passes the callback to `createPublicJob`
- `queue.getChildrenValues(job.id)` works fine, but the per-job method silently falls through to the empty fallback in `jobConversion.ts`
- Wire `createGetChildrenValuesHandler` in `processor.ts` (same pattern as `getState`, `log`, `updateProgress`)
- Add test verifying `job.getChildrenValues()` returns child results inside a worker handler

## Test plan

- [x] New test: `parent-child: job.getChildrenValues() works inside worker handler` (flow-advanced.test.ts)
- [x] All 12 flow-advanced tests pass
- [x] Full suite: 5025 pass, 1 skip, 1 fail (pre-existing flaky test in sandboxed processor)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jobs can now retrieve values from child tasks during processing in both embedded and remote modes.

* **Tests**
  * Added test coverage for child task value collection and aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->