### PR TITLE
Fix getChildrenValues returning empty in TCP mode

### DIFF
--- a/scripts/tcp/test-flow-children.ts
+++ b/scripts/tcp/test-flow-children.ts
@@ -1,0 +1,171 @@
+#!/usr/bin/env bun
+/**
+ * Flow Children Values Tests (TCP Mode)
+ *
+ * Verifies that getChildrenValues correctly unwraps the TCP response
+ * envelope and returns child job results to the parent processor.
+ */
+
+import { Queue, Worker, FlowProducer } from "../../src/client";
+
+const TCP_PORT = parseInt(process.env.TCP_PORT ?? "16789");
+const connOpts = { port: TCP_PORT };
+
+let passed = 0;
+let failed = 0;
+
+function ok(msg: string) {
+	console.log(`   ✅ ${msg}`);
+	passed++;
+}
+
+function fail(msg: string) {
+	console.log(`   ❌ ${msg}`);
+	failed++;
+}
+
+async function main() {
+	console.log("=== Flow Children Values Tests (TCP) ===\n");
+
+	const flow = new FlowProducer({ connection: connOpts, useLocks: false });
+
+	// ─────────────────────────────────────────────────
+	// Test 1: Parent reads child results via getChildrenValues
+	// ─────────────────────────────────────────────────
+	console.log("1. Testing PARENT READS CHILD RESULTS...");
+	{
+		const queueName = "tcp-flow-children-vals";
+		const q = new Queue(queueName, { connection: connOpts });
+		q.obliterate();
+		await Bun.sleep(100);
+
+		let parentValues: Record<string, unknown> | null = null;
+
+		const worker = new Worker(
+			queueName,
+			async (job) => {
+				const data = job.data as { role: string; value: number };
+
+				if (data.role === "child") {
+					return { computed: data.value * 10 };
+				}
+
+				if (data.role === "parent") {
+					const children = await job.getChildrenValues();
+					parentValues = children;
+					return { aggregated: true };
+				}
+
+				return {};
+			},
+			{
+				concurrency: 5,
+				connection: connOpts,
+				useLocks: false,
+			},
+		);
+
+		await flow.add({
+			name: "parent",
+			queueName,
+			data: { role: "parent" },
+			children: [
+				{ name: "child-a", queueName, data: { role: "child", value: 1 } },
+				{ name: "child-b", queueName, data: { role: "child", value: 2 } },
+			],
+		});
+
+		await Bun.sleep(5000);
+
+		if (parentValues === null) {
+			fail("Parent never received children values");
+		} else {
+			const values = Object.values(parentValues) as Array<{ computed?: number }>;
+			const computedResults = values
+				.map((v) => v?.computed)
+				.filter((v) => v !== undefined)
+				.sort();
+
+			if (computedResults.length === 2 && computedResults[0] === 10 && computedResults[1] === 20) {
+				ok(`Parent got child results: ${JSON.stringify(computedResults)}`);
+			} else {
+				fail(`Expected [10, 20], got ${JSON.stringify(parentValues)}`);
+			}
+		}
+
+		await worker.close();
+		q.obliterate();
+		q.close();
+	}
+
+	// ─────────────────────────────────────────────────
+	// Test 2: Queue.getChildrenValues query operation
+	// ─────────────────────────────────────────────────
+	console.log("\n2. Testing QUEUE getChildrenValues QUERY...");
+	{
+		const queueName = "tcp-flow-children-query";
+		const q = new Queue(queueName, { connection: connOpts });
+		q.obliterate();
+		await Bun.sleep(100);
+
+		const worker = new Worker(
+			queueName,
+			async (job) => {
+				const data = job.data as { role: string; value: number };
+				if (data.role === "child") {
+					return { result: data.value * 5 };
+				}
+				return { done: true };
+			},
+			{
+				concurrency: 5,
+				connection: connOpts,
+				useLocks: false,
+			},
+		);
+
+		const tree = await flow.add({
+			name: "root",
+			queueName,
+			data: { role: "parent" },
+			children: [
+				{ name: "c1", queueName, data: { role: "child", value: 3 } },
+				{ name: "c2", queueName, data: { role: "child", value: 7 } },
+			],
+		});
+
+		await Bun.sleep(5000);
+
+		const childValues = await q.getChildrenValues(tree.job.id);
+
+		if (!childValues || Object.keys(childValues).length === 0) {
+			fail(`getChildrenValues returned empty: ${JSON.stringify(childValues)}`);
+		} else {
+			const results = Object.values(childValues) as Array<{ result?: number }>;
+			const nums = results
+				.map((v) => v?.result)
+				.filter((v) => v !== undefined)
+				.sort();
+
+			if (nums.length === 2 && nums[0] === 15 && nums[1] === 35) {
+				ok(`Queue.getChildrenValues returned: ${JSON.stringify(nums)}`);
+			} else {
+				fail(`Expected [15, 35], got ${JSON.stringify(childValues)}`);
+			}
+		}
+
+		await worker.close();
+		q.obliterate();
+		q.close();
+	}
+
+	flow.close();
+
+	console.log("\n=== Summary ===");
+	console.log(`Passed: ${passed}`);
+	console.log(`Failed: ${failed}`);
+
+	process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch(console.error);

--- a/src/client/flowPush.ts
+++ b/src/client/flowPush.ts
@@ -128,7 +128,7 @@ export async function pushJobWithParent(
     removeOnComplete: opts.removeOnComplete,
     removeOnFail: opts.removeOnFail,
     parentId: parentRef?.id,
-    childIds,
+    childrenIds: childIds.length > 0 ? childIds : undefined,
     dependsOn: childIds.length > 0 ? childIds : undefined,
   });
 

--- a/src/client/queue/operations/query.ts
+++ b/src/client/queue/operations/query.ts
@@ -141,7 +141,8 @@ export async function getChildrenValues(
   }
   const response = await ctx.tcp!.send({ cmd: 'GetChildrenValues', id });
   if (!response.ok) return {};
-  return (response.values ?? {}) as Record<string, unknown>;
+  const data = (response as { data?: { values?: Record<string, unknown> } }).data;
+  return data?.values ?? {};
 }
 
 interface GetJobsOptions {

--- a/src/client/worker/processor.ts
+++ b/src/client/worker/processor.ts
@@ -132,7 +132,8 @@ function createGetChildrenValuesHandler(embedded: boolean, tcp: TcpConnection | 
       return manager.getChildrenValues(jobId(id));
     } else if (tcp) {
       const response = await tcp.send({ cmd: 'GetChildrenValues', id });
-      return (response as { values?: Record<string, unknown> }).values ?? {};
+      const data = (response as { data?: { values?: Record<string, unknown> } }).data;
+      return data?.values ?? {};
     }
     return {};
   };

--- a/src/domain/types/command.ts
+++ b/src/domain/types/command.ts
@@ -26,6 +26,8 @@ export interface PushCommand extends BaseCommand {
   readonly uniqueKey?: string;
   readonly jobId?: string; // customId
   readonly dependsOn?: string[];
+  readonly childrenIds?: string[];
+  readonly parentId?: string;
   readonly tags?: string[];
   readonly groupId?: string;
   readonly lifo?: boolean;

--- a/src/infrastructure/server/handlers/core.ts
+++ b/src/infrastructure/server/handlers/core.ts
@@ -63,6 +63,8 @@ export async function handlePush(
       uniqueKey: cmd.uniqueKey,
       customId: cmd.jobId,
       dependsOn: cmd.dependsOn?.map((id) => jobId(id)),
+      childrenIds: cmd.childrenIds?.map((id) => jobId(id)),
+      parentId: cmd.parentId ? jobId(cmd.parentId) : undefined,
       tags: cmd.tags,
       groupId: cmd.groupId,
       lifo: cmd.lifo,


### PR DESCRIPTION
Fixes two bugs that caused `getChildrenValues` to always return `{}` over TCP.

Bug 1: Response envelope unwrap
- The server handler uses `resp.data({ values })`, wrapping the response as `{ ok: true, data: { values } }`
- Both client call sites (`processor.ts`, `query.ts`) read `response.values` directly, which is always `undefined`
- Fix: read `response.data?.values` instead
- CodeRabbit correctly flagged this in PR #48 -- apologies for pushing back on that, the review was right

Bug 2: `childrenIds` not passed through TCP protocol
- `flowPush.ts` sends `childIds` (wrong field name, not in `PushCommand`)
- `PushCommand` type lacks `childrenIds`/`parentId` fields
- `handlePush` handler doesn't pass them to `queueManager.push()`
- Result: parent job created with `childrenIds: []`, so `getChildrenValues` finds no children
- Fix: correct the field name, add to type, pass through in handler

Test: `scripts/tcp/test-flow-children.ts` (TCP integration test with two test cases)

Let me know if this looks ok or if you'd like any changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for parent jobs to retrieve and process child job results.

* **Tests**
  * Added comprehensive test coverage for parent-child job relationships and child value retrieval in TCP flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->