### PR TITLE
fix(worker): reserve pull slots so leased jobs never exceed concurrency (#98)

### DIFF
--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -10,6 +10,12 @@ head:
 
 All notable changes to bunqueue are documented here.
 
+## [2.8.17] - 2026-06-16
+
+### Fixed — worker over-pulls jobs past `concurrency` (server `active` > concurrency); Issue #96 follow-up (RED→GREEN reproduction)
+
+- **A worker leased more jobs than its `concurrency` even though it never ran more than `concurrency` processors** (`src/client/worker/worker.ts`): the Issue #96 fix added a concurrency re-check before `startJob()`, which correctly caps *execution*, but `doPullBatch()` still computed free slots from a stale `activeJobs` read *before* the pull `await`, with no reservation. Overlapping `tryProcess()` runs (poll timer, every `finally`→`poll`, the `setImmediate` self-feed) therefore each pulled a batch against the same stale count and buffered the surplus into `pendingJobs`. Those buffered jobs are leased (locked + heartbeated), so the broker kept counting them as `active` — a worker with `concurrency: 3` reported `active: 5`/`6`, hoarded jobs it wasn't running, and starved other workers. `doPullBatch()` now reserves slots in a `pendingPull` counter held across the `await` and also subtracts already-buffered jobs, so `activeJobs + buffered + in-flight pull ≤ concurrency`; a second concurrent pull sees the reservation and pulls fewer (or zero) jobs. Server `active` now tracks `concurrency`.
+
 ## [2.8.16] - 2026-06-16
 
 ### Fixed — stale-ACK timeout resurrection (defect 3 from the destruction-validation audit; RED→GREEN reproduction)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunqueue",
-  "version": "2.8.16",
+  "version": "2.8.17",
   "description": "High-performance job queue for Bun & AI agents. SQLite persistence, cron scheduling, priorities, retries, DLQ, webhooks, native MCP server. Zero external dependencies.",
   "type": "module",
   "main": "dist/main.js",

--- a/src/client/worker/worker.ts
+++ b/src/client/worker/worker.ts
@@ -114,6 +114,12 @@ export class Worker<T = unknown, R = unknown> extends EventEmitter {
   private pendingJobs: Array<{ job: InternalJob; token: string | null }> = [];
   private pendingJobsHead = 0;
   private processingScheduled = false; // Prevent multiple setImmediate calls
+  // Slots reserved by in-flight doPullBatch() calls. Subtracted from free-slot
+  // accounting so overlapping pulls see each other and never collectively lease
+  // more than `concurrency` jobs (running + buffered + in-flight pull). Without
+  // this, each concurrent pull computes slots from the same stale `activeJobs`
+  // and over-pulls into the buffer, inflating the broker's `active` count.
+  private pendingPull = 0;
 
   // Drained event tracking
   private lastDrainedEmit = 0;
@@ -801,14 +807,32 @@ export class Worker<T = unknown, R = unknown> extends EventEmitter {
   }
 
   private async doPullBatch(): Promise<Array<{ job: InternalJob; token: string | null }>> {
-    const slots = this.opts.concurrency - this.activeJobs;
+    // Free slots = concurrency minus everything already leased or about to be:
+    //   - activeJobs            : jobs currently executing
+    //   - buffered              : pulled-but-unstarted jobs sitting in pendingJobs
+    //                             (e.g. group-limited jobs awaiting a free slot)
+    //   - pendingPull           : slots reserved by other in-flight pulls
+    // Reserving pendingPull across the await is what closes the over-pull race
+    // described in the report: a second concurrent pull now sees this one's
+    // reservation and pulls fewer (or zero) jobs, so the worker never leases
+    // more than `concurrency` jobs at once (server `active` <= concurrency).
+    const buffered = this.pendingJobs.length - this.pendingJobsHead;
+    const slots = this.opts.concurrency - this.activeJobs - buffered - this.pendingPull;
     const batchSize = Math.min(this.opts.batchSize, slots, 1000);
     if (batchSize <= 0) return [];
 
-    const config = this.getPullConfig();
-    return this.embedded
-      ? pullEmbedded(config, batchSize)
-      : pullTcp(config, this.tcp as NonNullable<typeof this.tcp>, batchSize, this._closing);
+    this.pendingPull += batchSize;
+    try {
+      const config = this.getPullConfig();
+      return await (this.embedded
+        ? pullEmbedded(config, batchSize)
+        : pullTcp(config, this.tcp as NonNullable<typeof this.tcp>, batchSize, this._closing));
+    } finally {
+      // Release the reservation: pulled jobs are now buffered/started (counted
+      // by activeJobs/pendingJobs), and a pull that returned fewer than asked
+      // must not leave phantom reservations that throttle later pulls.
+      this.pendingPull -= batchSize;
+    }
   }
 
   private startJob(job: InternalJob, token: string | null): void {

--- a/test/issue-overpull-leased.test.ts
+++ b/test/issue-overpull-leased.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Worker over-pulls jobs past `concurrency` (server `active` > concurrency)
+ *
+ * Follow-up to Issue #96. The #96 fix added a concurrency re-check before
+ * startJob() — guarding EXECUTION — so the number of running processors is
+ * correctly capped. But doPullBatch() still computes free slots from a stale
+ * `activeJobs` across the pull `await`, with no reservation. Overlapping
+ * tryProcess() runs (poll timer, every finally->poll, the setImmediate
+ * self-feed) therefore each pull a batch against the same stale count and
+ * buffer the surplus into `pendingJobs`. Those buffered jobs are leased
+ * (locked + heartbeated) so the broker keeps counting them as `active`:
+ * the user observed active=5/6 against concurrency=3.
+ *
+ * The leased set is `pulledJobIds` (running + buffered). This test asserts it
+ * never exceeds `concurrency`, which directly mirrors the server `active`
+ * count. We model a slow PULL (the report's trigger) so multiple tryProcess()
+ * runs suspend at the pull await at once; the real pull logic is unchanged.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { Queue, Worker, shutdownManager } from '../src/client';
+
+describe('Worker over-pull — leased (pulled) jobs never exceed concurrency', () => {
+  afterEach(() => {
+    shutdownManager();
+  });
+
+  test('pulledJobIds (running + buffered, == server active) stays <= concurrency under a fast-completion burst with slow pulls', async () => {
+    const CONCURRENCY = 3;
+    const TOTAL_JOBS = 40;
+
+    const queue = new Queue('overpull-leased', { embedded: true });
+    queue.obliterate();
+
+    let completed = 0;
+
+    const worker = new Worker(
+      'overpull-leased',
+      async () => {
+        // Hold the slot so the initial batch completes together, producing the
+        // burst of near-simultaneous finally->poll calls that triggers the race.
+        await Bun.sleep(20);
+        completed++;
+        return { ok: true };
+      },
+      {
+        embedded: true,
+        concurrency: CONCURRENCY,
+        heartbeatInterval: 0,
+      }
+    );
+
+    const internals = worker as unknown as {
+      doPullBatch: (...args: unknown[]) => Promise<unknown>;
+      pulledJobIds: Set<string>;
+    };
+
+    // Model a slow network round-trip on PULL (the issue's stated trigger).
+    // Keep the REAL pull logic and only add latency, so multiple tryProcess()
+    // runs suspend at the await simultaneously.
+    const realPull = internals.doPullBatch.bind(worker);
+    internals.doPullBatch = async (...args: unknown[]) => {
+      await Bun.sleep(25);
+      return realPull(...args);
+    };
+
+    // Sample the leased set (== broker `active`) continuously while draining.
+    let maxLeased = 0;
+    const sampler = setInterval(() => {
+      const leased = internals.pulledJobIds.size;
+      if (leased > maxLeased) maxLeased = leased;
+    }, 1);
+
+    for (let i = 0; i < TOTAL_JOBS; i++) {
+      await queue.add('task', { i });
+    }
+
+    const deadline = Date.now() + 15000;
+    while (completed < TOTAL_JOBS && Date.now() < deadline) {
+      await Bun.sleep(50);
+    }
+    clearInterval(sampler);
+
+    await worker.close();
+    queue.close();
+
+    // Sanity: the fix must not lose or stall jobs.
+    expect(completed).toBe(TOTAL_JOBS);
+
+    // THE BUG: leased jobs (running + buffered, holding locks) overshoot the
+    // limit even though running processors do not. This is the server active>3.
+    expect(maxLeased).toBeLessThanOrEqual(CONCURRENCY);
+  }, 30000);
+});


### PR DESCRIPTION
Fixes #98 (follow-up to #96).

## Problem

After the #96 fix, the number of jobs a worker **executes** is correctly capped at `concurrency`, but the broker still reports more `active` jobs than `concurrency` (e.g. `concurrency: 3` → `active: 5`/`6`). The extra jobs aren't running — they've been pulled and **leased** (locked + heartbeated) into the worker's `pendingJobs` buffer, so they inflate the server `active` count, hoard work, and starve other workers of the same queue.

## Root cause

`doPullBatch()` computes free slots from a stale `activeJobs` read **before** the pull `await`, with no reservation:

```ts
const slots = this.opts.concurrency - this.activeJobs;  // read before await
...
return pullTcp(config, this.tcp, batchSize, this._closing);  // await — leases on broker
```

The #96 re-check guards `startJob()` (execution), but nothing guards fetching. Overlapping `tryProcess()` runs (poll timer, every `finally`→`poll`, the `setImmediate` self-feed) each compute `slots` against the same stale `activeJobs` and pull a batch, buffering the surplus.

## Fix

Reserve slots in a `pendingPull` counter held across the `await`, and also subtract already-buffered jobs:

```ts
const buffered = this.pendingJobs.length - this.pendingJobsHead;
const slots = this.opts.concurrency - this.activeJobs - buffered - this.pendingPull;
const batchSize = Math.min(this.opts.batchSize, slots, 1000);
if (batchSize <= 0) return [];

this.pendingPull += batchSize;
try {
  return await (this.embedded ? pullEmbedded(...) : pullTcp(...));
} finally {
  this.pendingPull -= batchSize;
}
```

Now `activeJobs + buffered + in-flight pull ≤ concurrency`. A second concurrent pull sees the reservation and pulls fewer (or zero) jobs, so server `active` tracks `concurrency`. Subtracting `buffered` (beyond the report's suggestion) also covers the group-limiter case where leased jobs sit in the buffer. The #96 re-check remains as the execution-side guard.

## Test

`test/issue-overpull-leased.test.ts` samples `pulledJobIds.size` (running + buffered = server `active`) under a fast-completion burst with modelled slow pulls. RED: `maxLeased: 6`; GREEN: `≤ 3`.

## Verification

All three suites green:
- Unit: 5648 pass, 0 fail
- TCP integration: 59/59 suites
- Embedded integration: 36/36 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a worker concurrency over-pull issue where workers could lease more jobs than their configured concurrency limit due to stale accounting across overlapping pull operations. Workers now properly reserve and track available slots to ensure concurrency settings are respected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->